### PR TITLE
Fix armory embed pagination

### DIFF
--- a/armorBoard.js
+++ b/armorBoard.js
@@ -71,10 +71,10 @@ module.exports = function initArmorBoard({ client, db, DEV, ARMOR_CHANNEL_ID, ge
                 );
             }
 
-            // chunk into groups of 25
+            // chunk into groups of 24 (8 user rows) to avoid splitting a row across pages
             const pages = [];
-            for (let i = 0; i < allFields.length; i += 25) {
-                const slice = allFields.slice(i, i + 25);
+            for (let i = 0; i < allFields.length; i += 24) {
+                const slice = allFields.slice(i, i + 24);
                 const embed = new EmbedBuilder()
                     .setTitle('🛡️ Armor Board')
                     .setDescription('*Cloth & Leather only*')

--- a/boards.js
+++ b/boards.js
@@ -139,8 +139,9 @@ async function updateArmorEmbed(client, guild) {
         }
 
         const pages = [];
-        for (let i = 0; i < allFields.length; i += 25) {
-            const slice = allFields.slice(i, i + 25);
+        // Use groups of 24 fields (8 user rows) so a user's entry never spans pages
+        for (let i = 0; i < allFields.length; i += 24) {
+            const slice = allFields.slice(i, i + 24);
             const embed = new EmbedBuilder()
                 .setTitle('🛡️ Armor Board')
                 .setDescription('*Cloth, Leather, Rings & Hearts*')


### PR DESCRIPTION
## Summary
- avoid splitting user rows across pages in `armorBoard.js`
- avoid splitting user rows across pages in `boards.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e67a0475083218a960b59b00da40d