### PR TITLE
Fix assignment board pagination again

### DIFF
--- a/commands/setupassignments.js
+++ b/commands/setupassignments.js
@@ -19,6 +19,7 @@ module.exports = {
             .setColor(0x00AEFF);
         const msg = await ch.send({ embeds: [init] });
         await setMeta('board_message_id', msg.id);
+        await setMeta('board_message_ids', JSON.stringify([msg.id]));
 
         const ach = await guild.channels.fetch(ARMOR_CHANNEL_ID);
         const ainit = new EmbedBuilder()


### PR DESCRIPTION
## Summary
- store multiple assignment board message ids
- handle multiple pages when updating assignment board
- update setup command to store new metadata

## Testing
- `node --check boards.js`
- `node --check commands/setupassignments.js`


------
https://chatgpt.com/codex/tasks/task_e_68765f59fcc8832196a3ffd5d681b7ba