### PR TITLE
Update embed on role changes and add cleanup script

### DIFF
--- a/boards.js
+++ b/boards.js
@@ -1,7 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const { log, error } = require('./logger');
 const { getMeta, setMeta, DEV } = require('./db');
-const { fetchAllAssignments, getMeta, setMeta, DEV } = require('./db');
 const { professions } = require('./constants');
 
 const ASSIGNMENT_CHANNEL_ID = process.env.ASSIGNMENT_CHANNEL_ID;
@@ -23,7 +22,6 @@ async function updateAssignmentEmbed(client, guild) {
             }
         }
 
-        const assignMap = await fetchAllAssignments();
         const channel = await guild.channels.fetch(ASSIGNMENT_CHANNEL_ID);
         let msg = null;
         const stored = await getMeta('board_message_id');

--- a/commands/info.js
+++ b/commands/info.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { professions } = require('../constants');
-const { fetchAllAssignments } = require('../db');
 const { log } = require('../logger');
 
 module.exports = {
@@ -19,10 +18,6 @@ module.exports = {
         const avatar = target.displayAvatarURL({ dynamic: true });
         const member = await interaction.guild.members.fetch(uid);
         const pros = professions.filter(p => member.roles.cache.some(r => r.name === p));
-
-        const assignMap = await fetchAllAssignments();
-
-        const pros = assignMap[uid] || [];
         const focusedText = pros.length ? pros.join(', ') : 'None';
 
         const embed = new EmbedBuilder()

--- a/scripts/cleanupProfessionRoles.js
+++ b/scripts/cleanupProfessionRoles.js
@@ -1,0 +1,31 @@
+require('dotenv').config();
+const { Client, GatewayIntentBits } = require('discord.js');
+const { professions } = require('../constants');
+const { log, error } = require('../logger');
+
+const TOKEN = process.env.DISCORD_TOKEN;
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+client.once('ready', async () => {
+    log(`✅ Logged in as ${client.user.tag}`);
+    for (const guild of client.guilds.cache.values()) {
+        await guild.roles.fetch();
+        for (const role of guild.roles.cache.values()) {
+            for (const prof of professions) {
+                if (new RegExp(`^${prof} \\d+$`).test(role.name)) {
+                    try {
+                        await role.delete('Remove level-based profession role');
+                        log(`[Cleanup] Deleted role ${role.name} in ${guild.name}`);
+                    } catch (err) {
+                        error('[Cleanup] Failed to delete role', err);
+                    }
+                }
+            }
+        }
+    }
+    log('Cleanup finished');
+    process.exit(0);
+});
+
+client.login(TOKEN);


### PR DESCRIPTION
## Summary
- add script to remove profession level roles
- clean up board generation logic
- remove DB dependency from info and main bot file
- refresh assignment embed when profession roles change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688648f24b9c8321aa988292a130521f